### PR TITLE
Update phpstan to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true
-        }
+        },
+        "lock": false
     },
     "require": {
         "php": ">=8.1",
@@ -22,9 +23,9 @@
         "squizlabs/php_codesniffer": "^3.6",
         "phpmd/phpmd": "^2.14",
         "phpunit/phpunit": "^9.6",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.3"
     },
     "autoload": {

--- a/src/Constraint/InputConstraint.php
+++ b/src/Constraint/InputConstraint.php
@@ -7,6 +7,7 @@ use Symfony\Component\Validator\Constraint;
 
 class InputConstraint extends Constraint
 {
+    /** @var string */
     public const WRONG_VALUE_TYPE = '67ff49d5-9a61-47ad-80f1-960fd2beab6f';
 
     protected const ERROR_NAMES = [self::WRONG_VALUE_TYPE => 'WRONG_VALUE_TYPE',];


### PR DESCRIPTION
Add const typehint, because it's used as string in InputConstraintValidator
- docblock used because of php version in composer.json
- In case of child classes that overwrite the const with different type