### PR TITLE
Fix constraint argument deprecation notice

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,16 @@
+
+# Upgrade guide
+
+## From version 1.x to 2.0
+
+Update all usages of `InputConstraint`
+
+**Before**
+```php
+new InputConstraint(['arguments' => ..., 'options' => ...]);
+```
+
+**After**
+```php
+new InputConstraint(arguments: ..., options: ...);
+```

--- a/src/Constraint/InputConstraint.php
+++ b/src/Constraint/InputConstraint.php
@@ -14,30 +14,12 @@ class InputConstraint extends Constraint
 
     public string $wrongTypeMessage = 'Expect value to be of type Symfony\Component\Console\Input\InputInterface';
 
-    /** @var Constraint|Constraint[]|null */
-    public Constraint|array|null $arguments;
-
-    /** @var Constraint|Constraint[]|null */
-    public Constraint|array|null $options;
-
     /**
-     * @param array{
-     *     arguments?: Constraint|Constraint[],
-     *     options?: Constraint|Constraint[]
-     * }|null $options
+     * @param Constraint|Constraint[]|null $arguments
+     * @param Constraint|Constraint[]|null $options
      */
-    public function __construct(?array $options = null)
+    public function __construct(public Constraint|array|null $arguments = null, public Constraint|array|null $options = null)
     {
-        // make sure defaults are set
-        $options              = $options ?? [];
-        $options['arguments'] = $options['arguments'] ?? null;
-        $options['options']   = $options['options'] ?? null;
-
-        parent::__construct($options);
-    }
-
-    public function getRequiredOptions(): array
-    {
-        return ['arguments', 'options'];
+        parent::__construct();
     }
 }

--- a/src/Constraint/InputConstraint.php
+++ b/src/Constraint/InputConstraint.php
@@ -10,7 +10,7 @@ class InputConstraint extends Constraint
     /** @var string */
     public const WRONG_VALUE_TYPE = '67ff49d5-9a61-47ad-80f1-960fd2beab6f';
 
-    protected const ERROR_NAMES = [self::WRONG_VALUE_TYPE => 'WRONG_VALUE_TYPE',];
+    protected const ERROR_NAMES = [self::WRONG_VALUE_TYPE => 'WRONG_VALUE_TYPE'];
 
     public string $wrongTypeMessage = 'Expect value to be of type Symfony\Component\Console\Input\InputInterface';
 

--- a/src/Constraint/InputConstraintFactory.php
+++ b/src/Constraint/InputConstraintFactory.php
@@ -6,15 +6,11 @@ namespace DigitalRevolution\SymfonyConsoleValidation\Constraint;
 use DigitalRevolution\SymfonyConsoleValidation\ValidationRules;
 use DigitalRevolution\SymfonyValidationShorthand\ConstraintFactory;
 use DigitalRevolution\SymfonyValidationShorthand\Rule\InvalidRuleException;
-use Symfony\Component\Validator\Constraint;
 
 class InputConstraintFactory
 {
-    private ConstraintFactory $factory;
-
-    public function __construct(ConstraintFactory $factory = null)
+    public function __construct(private ConstraintFactory $factory = new ConstraintFactory())
     {
-        $this->factory = $factory ?? new ConstraintFactory();
     }
 
     /**
@@ -22,11 +18,16 @@ class InputConstraintFactory
      */
     public function createConstraint(ValidationRules $validationRules): InputConstraint
     {
-        $options = [];
-        foreach ($validationRules->getDefinitions() as $key => $definitions) {
-            $options[$key] = $this->factory->fromRuleDefinitions($definitions, true);
+        $definitions = $validationRules->getDefinitions();
+        $arguments   = $options = null;
+
+        if (isset($definitions['arguments'])) {
+            $arguments = $this->factory->fromRuleDefinitions($definitions['arguments'], true);
+        }
+        if (isset($definitions['options'])) {
+            $options = $this->factory->fromRuleDefinitions($definitions['options'], true);
         }
 
-        return new InputConstraint($options);
+        return new InputConstraint($arguments, $options);
     }
 }

--- a/tests/Unit/Constraint/InputConstraintFactoryTest.php
+++ b/tests/Unit/Constraint/InputConstraintFactoryTest.php
@@ -47,6 +47,6 @@ class InputConstraintFactoryTest extends TestCase
         $constraintA = new Assert\NotNull();
         $constraintB = new Assert\NotBlank();
         $result      = $this->factory->createConstraint(new ValidationRules(['arguments' => $constraintA, 'options' => $constraintB]));
-        static::assertEquals(new InputConstraint(['arguments' => $constraintA, 'options' => $constraintB]), $result);
+        static::assertEquals(new InputConstraint($constraintA, $constraintB), $result);
     }
 }

--- a/tests/Unit/Constraint/InputConstraintTest.php
+++ b/tests/Unit/Constraint/InputConstraintTest.php
@@ -31,26 +31,8 @@ class InputConstraintTest extends TestCase
     {
         $constraintA = new NotBlank();
         $constraintB = new NotNull();
-        $constraint  = new InputConstraint(['arguments' => $constraintA, 'options' => $constraintB]);
+        $constraint  = new InputConstraint($constraintA, $constraintB);
         static::assertSame($constraintA, $constraint->arguments);
         static::assertSame($constraintB, $constraint->options);
-    }
-
-    /**
-     * @covers ::__construct
-     */
-    public function testConstructIncorrectOption(): void
-    {
-        $this->expectException(InvalidOptionsException::class);
-        new InputConstraint(['invalid' => 'invalid']);
-    }
-
-    /**
-     * @covers ::getRequiredOptions
-     */
-    public function testGetRequiredOptions(): void
-    {
-        $constraint = new InputConstraint();
-        static::assertSame(['arguments', 'options'], $constraint->getRequiredOptions());
     }
 }

--- a/tests/Unit/Constraint/InputConstraintValidatorTest.php
+++ b/tests/Unit/Constraint/InputConstraintValidatorTest.php
@@ -52,7 +52,7 @@ class InputConstraintValidatorTest extends TestCase
     {
         $definition = new InputDefinition([new InputArgument('email', InputArgument::REQUIRED)]);
         $input      = new ArrayInput($data, $definition);
-        $constraint = new InputConstraint(['arguments' => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())])]);
+        $constraint = new InputConstraint(new Assert\Collection(['email' => new Assert\Required(new Assert\Email())]));
         $this->context->setConstraint($constraint);
         $this->validator->validate($input, $constraint);
         static::assertCount($success ? 0 : 1, $this->context->getViolations());
@@ -72,7 +72,7 @@ class InputConstraintValidatorTest extends TestCase
             ]
         );
         $input      = new ArrayInput($data, $definition);
-        $constraint = new InputConstraint(['options' => new Assert\Collection(['email' => new Assert\Optional(new Assert\Email())])]);
+        $constraint = new InputConstraint(options: new Assert\Collection(['email' => new Assert\Optional(new Assert\Email())]));
         $this->context->setConstraint($constraint);
         $this->validator->validate($input, $constraint);
         static::assertCount($success ? 0 : 1, $this->context->getViolations());


### PR DESCRIPTION
Breaking changes: yes

InputConstraint constructor argument changed from `$options` to named arguments.